### PR TITLE
Add `/subscriptions` API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ catalogs.items
   POST   - /catalogs/{catalogName}/items
   PATCH  - /catalogs/{catalogName}/items
   DELETE - /catalogs/{catalogName}/items
+subscriptions
+  PUT    - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}
+subscriptions.user
+  PATCH  - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
+  DELETE - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
 ```
 
 ### Development

--- a/lib/api.js
+++ b/lib/api.js
@@ -194,5 +194,16 @@ module.exports = [
         methods: ['get', 'put', 'post', 'patch', 'delete']
       }
     ]
+  },
+  {
+    resource: 'subscriptions',
+    methods: ['put'],
+    subResources: [
+      {
+        resource: 'user',
+        urlPrefix: '/subscriptions/{subscriptionGroup}/{subscriptionGroupId}',
+        methods: ['patch', 'delete']
+      }
+    ]
   }
 ]

--- a/lib/iterable.js
+++ b/lib/iterable.js
@@ -53,6 +53,7 @@ const create = apiKey => {
     messageTypes: require('./resources/messageTypes')(request),
     push: require('./resources/push')(request),
     sms: require('./resources/sms')(request),
+    subscriptions: require('./resources/subscriptions')(request),
     users: require('./resources/users')(request),
     webPush: require('./resources/webPush')(request),
     workflows: require('./resources/workflows')(request)

--- a/lib/resources/subscriptions.js
+++ b/lib/resources/subscriptions.js
@@ -1,0 +1,36 @@
+/**
+
+  PUT    - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}?action={action}
+  PATCH  - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
+  DELETE - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
+
+*/
+const BASE = '/subscriptions'
+
+const subscriptionsFactory = request => {
+  return {
+    user: _subscriptionsUserFactory(request),
+
+    bulkSubscribe ({ subscriptionGroup, subscriptionGroupId, data }) {
+      return request.put(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=subscribe`, data)
+    },
+
+    bulkUnsubscribe ({ subscriptionGroup, subscriptionGroupId, data }) {
+      return request.put(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=unsubscribe`, data)
+    }
+  }
+}
+
+const _subscriptionsUserFactory = request => {
+  return {
+    subscribe ({ subscriptionGroup, subscriptionGroupId, userEmail }) {
+      return request.patch(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+    },
+
+    unsubscribe ({ subscriptionGroup, subscriptionGroupId, userEmail }) {
+      return request.delete(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+    }
+  }
+}
+
+module.exports = subscriptionsFactory

--- a/test/resources/subscriptions.test.js
+++ b/test/resources/subscriptions.test.js
@@ -1,0 +1,46 @@
+const factory = require('../../lib/resources/subscriptions')
+
+const BASE = '/subscriptions'
+const USER_BASE = '/subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user'
+
+const request = {
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn()
+}
+const client = factory(request)
+const subscriptionGroup = 'messageChannel'
+const subscriptionGroupId = '1234'
+const data = {
+  users: [
+    'some@email.com'
+  ]
+}
+
+describe(BASE, () => {
+  it(`PUT ${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=subscribe`, () => {
+    client.bulkSubscribe({ subscriptionGroup, subscriptionGroupId, data })
+    expect(request.put).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=subscribe`, data)
+  })
+
+  it(`PUT ${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=unsubscribe`, () => {
+    client.bulkUnsubscribe({ subscriptionGroup, subscriptionGroupId, data })
+    expect(request.put).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=unsubscribe`, data)
+  })
+})
+
+describe(USER_BASE, () => {
+  it(`PATCH ${USER_BASE}/{userEmail}`, () => {
+    const userEmail = 'some@email.com'
+    client.user.subscribe({ subscriptionGroup, subscriptionGroupId, userEmail })
+    expect(request.patch).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+  })
+
+  it(`DELETE ${USER_BASE}/{userEmail}`, () => {
+    const userEmail = 'some@email.com'
+    client.user.unsubscribe({ subscriptionGroup, subscriptionGroupId, userEmail })
+    expect(request.delete).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+  })
+})


### PR DESCRIPTION
This PR adds support for the `/subscriptions` API endpoint on Iterable. The API here is a bit different than other parts of the Iterable API, so hopefully I implemented this in an appropriate manner. Per the README, there are 3 actual API endpoints used. However, to simplify usage, for the bulk subscriptions case, I abstracted that out into two convenience API methods: `bulkSubscribe` and `bulkUnsubscribe` -- under the hood, they call the same API but with a different `action` query parameter.

For the single user APIs, those are implemented with a `subscribe` and `unsubscribe` method.

I wasn't sure how to properly represent the first (bulk) API call in `api.js`, but all tests seem to pass this way so leaving it as-is.

Feedback welcomed. This fixes #101. 