### PR TITLE
Move `debug` to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   },
   "homepage": "https://github.com/geoffdutton/iterable-api",
   "dependencies": {
-    "axios": "^0.21.4"
+    "axios": "^0.21.4",
+    "debug": "^4.3.1"
   },
   "devDependencies": {
     "coveralls": "^3.1.0",
-    "debug": "^4.3.1",
     "jest": "^27.1.1",
     "standard": "^16.0.3"
   },


### PR DESCRIPTION
The debug library is used by the project outside of development/testing, so if one installs the library with only production dependencies, it throws an exception due to the missing library.

This is remedied by moving `debug` into `dependencies` instead of `devDependencies`.

Fixes #107 