### PR TITLE
Add /subscriptions and /users/bulkUpdateSubscriptions endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ catalogs.items
   POST   - /catalogs/{catalogName}/items
   PATCH  - /catalogs/{catalogName}/items
   DELETE - /catalogs/{catalogName}/items
+subscriptions
+  PUT    - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}
+subscriptions.user
+  PATCH  - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
+  DELETE - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
 ```
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node Iterable API
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
-[![Build Status](https://travis-ci.org/geoffdutton/iterable-api.svg?branch=master)](https://travis-ci.org/geoffdutton/iterable-api)
+[![Node CI](https://github.com/geoffdutton/iterable-api/actions/workflows/nodejs.yml/badge.svg)](https://github.com/geoffdutton/iterable-api/actions/workflows/nodejs.yml)
 [![Coverage Status](https://coveralls.io/repos/github/geoffdutton/iterable-api/badge.svg?branch=master)](https://coveralls.io/github/geoffdutton/iterable-api?branch=master)
 [![npm version](https://badge.fury.io/js/node-iterable-api.svg)](https://badge.fury.io/js/node-iterable-api)
 [![Known Vulnerabilities](https://snyk.io/test/github/geoffdutton/iterable-api/badge.svg)](https://snyk.io/test/github/geoffdutton/iterable-api)

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ catalogs.items
   PATCH  - /catalogs/{catalogName}/items
   DELETE - /catalogs/{catalogName}/items
 subscriptions
-  PUT    - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}
+  PUT    - /subscriptions
 subscriptions.user
-  PATCH  - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
-  DELETE - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
+  PATCH  - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user
+  DELETE - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user
 ```
 
 ### Development
@@ -153,3 +153,4 @@ node index.js
 
 ### Contributors
 - [julianmclain](https://github.com/julianmclain)
+- [dpolivy](https://github.com/dpolivy)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ users
   POST   - /users/bulkUpdate
   POST   - /users/registerDeviceToken
   POST   - /users/updateSubscriptions
+  POST   - /users/bulkUpdateSubscriptions
   GET    - /users/getFields
   GET    - /users/getSentMessages
   POST   - /users/disableDevice

--- a/lib/api.js
+++ b/lib/api.js
@@ -73,6 +73,10 @@ module.exports = [
         method: 'post'
       },
       {
+        name: 'bulkUpdateSubscriptions',
+        method: 'post'
+      },
+      {
         name: 'getFields',
         method: 'get'
       },

--- a/lib/api.js
+++ b/lib/api.js
@@ -194,5 +194,16 @@ module.exports = [
         methods: ['get', 'put', 'post', 'patch', 'delete']
       }
     ]
+  },
+  {
+    resource: 'subscriptions',
+    methods: ['put'],
+    subResources: [
+      {
+        resource: 'user',
+        urlPrefix: '/subscriptions/{subscriptionGroup}/{subscriptionGroupId}',
+        methods: ['patch', 'delete']
+      }
+    ]
   }
 ]

--- a/lib/iterable.js
+++ b/lib/iterable.js
@@ -53,6 +53,7 @@ const create = apiKey => {
     messageTypes: require('./resources/messageTypes')(request),
     push: require('./resources/push')(request),
     sms: require('./resources/sms')(request),
+    subscriptions: require('./resources/subscriptions')(request),
     users: require('./resources/users')(request),
     webPush: require('./resources/webPush')(request),
     workflows: require('./resources/workflows')(request)

--- a/lib/resources/subscriptions.js
+++ b/lib/resources/subscriptions.js
@@ -1,0 +1,36 @@
+/**
+
+  PUT    - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}?action={action}
+  PATCH  - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
+  DELETE - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
+
+*/
+const BASE = '/subscriptions'
+
+const subscriptionsFactory = request => {
+  return {
+    user: _subscriptionsUserFactory(request),
+
+    bulkSubscribe ({ subscriptionGroup, subscriptionGroupId, data }) {
+      return request.put(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=subscribe`, data)
+    },
+
+    bulkUnsubscribe ({ subscriptionGroup, subscriptionGroupId, data }) {
+      return request.put(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=unsubscribe`, data)
+    }
+  }
+}
+
+const _subscriptionsUserFactory = request => {
+  return {
+    subscribe ({ subscriptionGroup, subscriptionGroupId, userEmail }) {
+      return request.patch(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+    },
+
+    unsubscribe ({ subscriptionGroup, subscriptionGroupId, userEmail }) {
+      return request.delete(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+    }
+  }
+}
+
+module.exports = subscriptionsFactory

--- a/lib/resources/subscriptions.js
+++ b/lib/resources/subscriptions.js
@@ -2,7 +2,9 @@
 
   PUT    - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}?action={action}
   PATCH  - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
+  PATCH  - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/byUserId/{userId}
   DELETE - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user/{userEmail}
+  DELETE - /subscriptions/{subscriptionGroup}/{subscriptionGroupId}/byUserId/{userId}
 
 */
 const BASE = '/subscriptions'
@@ -22,19 +24,23 @@ const subscriptionsFactory = request => {
 }
 
 const _subscriptionsUserFactory = request => {
+  const getBaseUrl = ({ subscriptionGroup, subscriptionGroupId, userEmail, userId }) => {
+    let urlPath = `${BASE}/${subscriptionGroup}/${subscriptionGroupId}`
+    if (userEmail) {
+      urlPath += `/user/${userEmail}`
+    } else {
+      urlPath += `/byUserId/${userId}`
+    }
+    return urlPath
+  }
+
   return {
-    subscribe ({ subscriptionGroup, subscriptionGroupId, userEmail, userId }) {
-      let urlPath = `${BASE}/${subscriptionGroup}/${subscriptionGroupId}`
-      if (userEmail) {
-        urlPath += `/user/${userEmail}`
-      } else {
-        urlPath += `/byUserId/${userId}`
-      }
-      return request.patch(urlPath)
+    subscribe (data) {
+      return request.patch(getBaseUrl(data))
     },
 
-    unsubscribe ({ subscriptionGroup, subscriptionGroupId, userEmail }) {
-      return request.delete(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+    unsubscribe (data) {
+      return request.delete(getBaseUrl(data))
     }
   }
 }

--- a/lib/resources/subscriptions.js
+++ b/lib/resources/subscriptions.js
@@ -23,8 +23,14 @@ const subscriptionsFactory = request => {
 
 const _subscriptionsUserFactory = request => {
   return {
-    subscribe ({ subscriptionGroup, subscriptionGroupId, userEmail }) {
-      return request.patch(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+    subscribe ({ subscriptionGroup, subscriptionGroupId, userEmail, userId }) {
+      let urlPath = `${BASE}/${subscriptionGroup}/${subscriptionGroupId}`
+      if (userEmail) {
+        urlPath += `/user/${userEmail}`
+      } else {
+        urlPath += `/byUserId/${userId}`
+      }
+      return request.patch(urlPath)
     },
 
     unsubscribe ({ subscriptionGroup, subscriptionGroupId, userEmail }) {

--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -7,6 +7,7 @@
  POST   - /users/bulkUpdate
  POST   - /users/registerDeviceToken
  POST   - /users/updateSubscriptions
+ POST   - /users/bulkUpdateSubscriptions
  POST   - /users/registerBrowserToken
  GET    - /users/byUserId
  DELETE - /users/byUserId
@@ -90,6 +91,10 @@ const usersFactory = request => {
 
     updateSubscriptions (data) {
       return request.post(`${BASE}/updateSubscriptions`, data)
+    },
+
+    bulkUpdateSubscriptions (data) {
+      return request.post(`${BASE}/bulkUpdateSubscriptions`, data)
     },
 
     registerBrowserToken ({ browserToken, email, userId }) {

--- a/test/resources/subscriptions.test.js
+++ b/test/resources/subscriptions.test.js
@@ -56,4 +56,17 @@ describe(USER_BASE, () => {
     client.user.unsubscribe({ subscriptionGroup, subscriptionGroupId, userEmail })
     expect(request.delete).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
   })
+
+  it(`DELETE ${USER_BASE}/byUserId/{userId}`, () => {
+    const userId = 'some-id'
+    client.user.unsubscribe({ subscriptionGroup, subscriptionGroupId, userId })
+    expect(request.delete).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/byUserId/${userId}`)
+  })
+
+  it(`DELETE ${USER_BASE}/{userEmail} - userEmail takes precedence`, () => {
+    const userEmail = 'some@email.com'
+    const userId = 'some-id'
+    client.user.unsubscribe({ subscriptionGroup, subscriptionGroupId, userEmail, userId })
+    expect(request.delete).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+  })
 })

--- a/test/resources/subscriptions.test.js
+++ b/test/resources/subscriptions.test.js
@@ -1,0 +1,46 @@
+const factory = require('../../lib/resources/subscriptions')
+
+const BASE = '/subscriptions'
+const USER_BASE = '/subscriptions/{subscriptionGroup}/{subscriptionGroupId}/user'
+
+const request = {
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn()
+}
+const client = factory(request)
+const subscriptionGroup = 'messageChannel'
+const subscriptionGroupId = '1234'
+const data = {
+  users: [
+    'some@email.com'
+  ]
+}
+
+describe(BASE, () => {
+  it(`PUT ${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=subscribe`, () => {
+    client.bulkSubscribe({ subscriptionGroup, subscriptionGroupId, data })
+    expect(request.put).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=subscribe`, data)
+  })
+
+  it(`PUT ${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=unsubscribe`, () => {
+    client.bulkUnsubscribe({ subscriptionGroup, subscriptionGroupId, data })
+    expect(request.put).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}?action=unsubscribe`, data)
+  })
+})
+
+describe(USER_BASE, () => {
+  it(`PATCH ${USER_BASE}/{userEmail}`, () => {
+    const userEmail = 'some@email.com'
+    client.user.subscribe({ subscriptionGroup, subscriptionGroupId, userEmail })
+    expect(request.patch).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+  })
+
+  it(`DELETE ${USER_BASE}/{userEmail}`, () => {
+    const userEmail = 'some@email.com'
+    client.user.unsubscribe({ subscriptionGroup, subscriptionGroupId, userEmail })
+    expect(request.delete).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+  })
+})

--- a/test/resources/subscriptions.test.js
+++ b/test/resources/subscriptions.test.js
@@ -38,6 +38,19 @@ describe(USER_BASE, () => {
     expect(request.patch).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
   })
 
+  it(`PATCH ${USER_BASE}/byUserId/{userId}`, () => {
+    const userId = 'some-id'
+    client.user.subscribe({ subscriptionGroup, subscriptionGroupId, userId })
+    expect(request.patch).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/byUserId/${userId}`)
+  })
+
+  it(`PATCH ${USER_BASE}/{userEmail} - userEmail takes precedence`, () => {
+    const userEmail = 'some@email.com'
+    const userId = 'some-id'
+    client.user.subscribe({ subscriptionGroup, subscriptionGroupId, userEmail, userId })
+    expect(request.patch).toHaveBeenCalledWith(`${BASE}/${subscriptionGroup}/${subscriptionGroupId}/user/${userEmail}`)
+  })
+
   it(`DELETE ${USER_BASE}/{userEmail}`, () => {
     const userEmail = 'some@email.com'
     client.user.unsubscribe({ subscriptionGroup, subscriptionGroupId, userEmail })

--- a/test/resources/users.test.js
+++ b/test/resources/users.test.js
@@ -88,6 +88,27 @@ describe(BASE, () => {
       }
     },
     {
+      name: 'bulkUpdateSubscriptions',
+      expectedVal: {
+        updateSubscriptionsRequests: [
+          {
+            userId: 'some-user-id',
+            emailListIds: [
+              0
+            ],
+            unsubscribedChannelIds: [
+              0
+            ],
+            unsubscribedMessageTypeIds: [
+              0
+            ],
+            campaignId: 0,
+            templateId: 0
+          }
+        ]
+      }
+    },
+    {
       name: 'registerBrowserToken',
       expectedVal: {
         email: 'some@email.com',


### PR DESCRIPTION
Updated version of #113 with some additional fies.

I have tested this against the Iterable API and it is working, with the caveat that I don't seem to have access to the `/byUserId/` flavor of the bulk subscriptions update, but the syntax of the request should be correct. I've asked to get this enabled but I see no reason it shouldn't work once that happens.