### PR TITLE
Add campaigns get method to retrieve campaigns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Node.js wrapper for the Iterable API (`node-iterable-api`), providing a clean interface to interact with Iterable's marketing automation platform. The package wraps Iterable's REST API endpoints into JavaScript methods.
+
+## Architecture
+
+- **Entry Point**: `index.js` - Simple module export that re-exports the main Iterable class
+- **Core Library**: `lib/` directory contains the main implementation
+  - `iterable.js` - Main factory function that creates client instances with all resource modules
+  - `request.js` - HTTP client wrapper using Axios with API key authentication
+  - `api.js` - Configuration array defining all available API resources and methods
+  - `resources/` - Individual resource modules (users, lists, events, campaigns, etc.)
+- **Resource Pattern**: Each resource in `lib/resources/` exports a factory function that accepts a request instance and returns methods for that resource
+- **Testing**: Uses Jest with mock implementations in `lib/__mocks__/`
+
+## Development Commands
+
+```bash
+# Run tests with coverage and linting
+npm test
+
+# Test-driven development (watch mode)
+npm run tdd
+
+# List all implemented resources
+node index.js
+```
+
+## Testing Setup
+
+- Uses Jest as the test framework
+- Standard.js for linting (runs automatically with `npm test`)
+- Requires `ITERABLE_API_KEY=fake-key` environment variable for tests
+- Mock implementations in `lib/__mocks__/request.js`
+- Test helper utilities in `test/resources/helper.js`
+
+## API Resource Structure
+
+Resources are defined in `lib/api.js` and follow this pattern:
+- **methods**: Direct HTTP methods on the resource (get, post, delete, etc.)
+- **actions**: Named actions that map to specific endpoints
+- **subResources**: Nested resources with their own methods (e.g., catalogs.items, catalogs.fieldMappings)
+
+Each resource module exports a factory function that:
+1. Takes a request instance as parameter
+2. Returns an object with methods corresponding to API endpoints
+3. Handles URL construction and parameter formatting
+
+## Key Files to Understand
+
+- `lib/api.js:1` - Complete API resource definitions
+- `lib/iterable.js:6` - Main client factory function
+- `lib/request.js:4` - HTTP client with Iterable API authentication
+- `lib/resources/users.js:20` - Example resource implementation pattern

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ inApp
 push
   POST   - /push/target
 campaigns
+  GET    - /campaigns
   POST   - /campaigns/create
 channels
   GET    - /channels

--- a/lib/api.js
+++ b/lib/api.js
@@ -110,6 +110,7 @@ module.exports = [
   },
   {
     resource: 'campaigns',
+    methods: ['get'],
     actions: [
       {
         name: 'create',

--- a/lib/resources/campaigns.js
+++ b/lib/resources/campaigns.js
@@ -1,6 +1,7 @@
 /**
 
  POST   - /campaigns/create
+ GET    - /campaigns
 
 */
 
@@ -30,6 +31,10 @@ const factory = request => {
         defaultTimeZone,
         dataFields
       })
+    },
+
+    get () {
+      return request.get(BASE)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/liaison-inc/iterable-api.git"
+    "url": "git+https://github.com/geoffdutton/iterable-api.git"
   },
   "keywords": [
     "iterable",
@@ -22,9 +22,9 @@
   "author": "Geoff Dutton <g.dutton@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/liaison-inc/iterable-api/issues"
+    "url": "https://github.com/geoffdutton/iterable-api/issues"
   },
-  "homepage": "https://github.com/liaison-inc/iterable-api",
+  "homepage": "https://github.com/geoffdutton/iterable-api",
   "dependencies": {
     "axios": "^0.25.0",
     "debug": "^4.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-iterable-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Wrapper for Iterable API",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/geoffdutton/iterable-api.git"
+    "url": "git+https://github.com/liaison-inc/iterable-api.git"
   },
   "keywords": [
     "iterable",
@@ -22,9 +22,9 @@
   "author": "Geoff Dutton <g.dutton@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/geoffdutton/iterable-api/issues"
+    "url": "https://github.com/liaison-inc/iterable-api/issues"
   },
-  "homepage": "https://github.com/geoffdutton/iterable-api",
+  "homepage": "https://github.com/liaison-inc/iterable-api",
   "dependencies": {
     "axios": "^0.25.0",
     "debug": "^4.3.3"


### PR DESCRIPTION
## Summary
- Add `get()` method to campaigns resource to retrieve campaigns via GET /campaigns endpoint
- Update API documentation comment to reflect the new GET endpoint
- Enables fetching campaign data from the Iterable API

## Test plan
- [x] Method implemented following existing resource patterns
- [x] API documentation comment updated
- [x] Maintains consistency with other resource implementations